### PR TITLE
Add extended_responses as valid param for all API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CloudMine JavaScript Library Change Log
 
+## 0.10.0 
+* Add support for atomic operations via the extend_responses param
+
 ## v0.9.15 January 5, 2016
 * Add support for an endpoint version to be passed to the WebService as an option.
 * Fixes a few small outstanding bugs

--- a/js/cloudmine.js
+++ b/js/cloudmine.js
@@ -1,6 +1,6 @@
-/* CloudMine JavaScript Library v0.9.x cloudmineinc.com | https://github.com/cloudmine/cloudmine-js/blob/master/LICENSE */
+/* CloudMine JavaScript Library v0.10.x cloudmineinc.com | https://github.com/cloudmine/cloudmine-js/blob/master/LICENSE */
 (function() {
-  var version = '0.9.16';
+  var version = '0.10.0';
 
   /**
    * Construct a new WebService instance
@@ -1954,7 +1954,8 @@
     userid: 'userid',
     count: 'count',
     distance: 'distance', // Only applies to geo-query searches
-    units: 'units' // Only applies to geo-query searches
+    units: 'units', // Only applies to geo-query searches
+    extended_responses: 'extended_responses' // Only applies to atomic operations
   };
 
   // Default jQuery ajax configuration.


### PR DESCRIPTION
Adds support for extended_responses param to be passed to API calls. This param is only used for atomic operations.